### PR TITLE
fixed exception handler for dtc compile command

### DIFF
--- a/lib/bone.js
+++ b/lib/bone.js
@@ -175,8 +175,9 @@ module.exports = {
         function onDTSWrite() {
             debug('Compiling dts file');
             var command = 'dtc -O dtb -o ' + dtboFilename + ' -b 0 -@ ' + dtsFilename;
+            var result = exec(command);
 
-            if (exec(command).code !== 0) {
+            if (result.code !== 0) {
                 throw new verror(result.output, " Compiling of dts file failed.");
             }
 


### PR DESCRIPTION
This pull request fixes a ReferenceError thrown by `onDTSWrite()` when the dtc compile command fails.