### PR TITLE
Autoload Universial and Fixes for multiple i2c.open same path

### DIFF
--- a/examples/i2c_multiple_adafruitled7Segs.js
+++ b/examples/i2c_multiple_adafruitled7Segs.js
@@ -1,0 +1,200 @@
+﻿// Created by Andrew DeVries, Digital Example LLC move to test path + address to allow multiple i2c slaves  Issue   #68
+
+
+//Sugested this be run with Debug enabled so can view Bone debug
+//sudo DEBUG=bone node testBone.js
+// Test coded to use Qty 2 adafruit LED 7 Segment displays    https://www.adafruit.com/products/879
+// on the second LED 7 Segment display solder pads A1 so its i2c address is moved from default 0x70 to 0x71
+
+var boneScript;
+
+try {
+    //diable autoload of cape in octalbone until issue #67
+    // if running the command 'cat /sys/devices/platform/bone_capemgr/slots' output is
+    //0: PF---- -1
+    //1: PF---- -1
+    //2: PF---- -1
+    //3: PF---- -1
+    // with no 4th or greater option of the universal cap being set then removing this line may resolve
+    // This does npt work on the BeagleBoneGreen the current AUTO_LOAD_CAPE logic doesn't load the correct overlay for the BBG so it errors.
+    process.env['AUTO_LOAD_CAPE'] = '0';
+    //boneScript = require('bonescript');
+    boneScript = require('octalbonescript');
+    boneScript.getPlatform(function (err, x) {
+        console.log('bonescript getPlatform');
+        // console.log('version = ' + x.version);
+        console.log('serialNumber = ' + x.serialNumber);
+        console.log('dogtag = ' + x.dogtag);
+    });
+
+    //Adafruit LED Backpack 7 Segment Registers
+    var HT16K33_BLINK_CMD = 0x80;
+    var HT16K33_BLINK_DISPLAYON = 0x01;
+    var HT16K33_BLINK_OFF = 0;
+    var HT16K33_BLINK_2HZ = 1;
+    var HT16K33_BLINK_1HZ = 2;
+    var HT16K33_BLINK_HALFHZ = 3;
+    var HT16K33_CMD_BRIGHTNESS = 0xE0;
+    var HT16K33_CMD_SYSTEM = 0x20;
+    var buffer = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+    var digits = [
+        0x3F, //0
+        0x06, //1
+        0x5B, //2
+        0x4F, //3
+        0x66, //4
+        0x6D, //5
+        0x7D, //6
+        0x07, //7
+        0x7F, //8
+        0x6F, //9
+        0x77, //A
+        0x7C, //B
+        0x39, //C
+        0x5E, //D
+        0x79, //E
+        0x71, //F
+        0x00  //blank
+    ];
+
+
+
+    //Method to open i2c backpacks and write 00:00 to the diplays so you know they are connected correctly
+    var testI2cOpen = function (i2cDevice, i2cAddress, Callback) {
+
+        boneScript.i2c.open(i2cDevice, i2cAddress,
+            function () {
+                //Not realy used not sure why it is needed
+                console.log('bonescript i2c.open handler');
+            },
+            function (err, port) {
+
+                if (err) {
+                    debug('bonescript i2c.open error %', err);
+                    console.log('bonescript i2c.open Error');
+                    console.dir(err, { depth: null });
+                    debug('bonescript i2c.open error %s', err);
+                    if (Callback) {
+                        Callback(err, null);
+                    }
+                } else {
+                    //i2cdevice = port;
+                    console.log('bonescript i2c.open success ', port);
+                    // Turn on the LED Ocillator
+                    //port.setAddress(objOptions.I2CAddress);
+                    port.writeBytes(HT16K33_CMD_SYSTEM | HT16K33_BLINK_DISPLAYON, [0x00],
+                        function (err) {
+                            if (err) {
+                                console.log('Error in init DisplayOn %s', err);
+                                if (Callback) {
+                                    Callback(err, null);
+                                }
+                            } else {
+                                console.log('ocillator enabled ' + i2cAddress + " device " + i2cDevice);
+                                //i2cdevice.setAddress(objOptions.I2CAddress);
+                                port.writeBytes(HT16K33_BLINK_CMD | 0x01, [0x00], function (err) {
+                                    if (err) {
+                                        console.log('Error in init setBlinkRate %s', err);
+                                        if (Callback) {
+                                            Callback(err, null);
+                                        }
+                                    } else {
+                                        console.log('display enabled ' + i2cAddress + " device " + i2cDevice);
+                                        //i2cdevice.setAddress(objOptions.I2CAddress);
+                                        port.writeBytes(HT16K33_CMD_BRIGHTNESS | 15, [0x00], function (err) {
+                                            if (err) {
+                                                console.log('Error in init setBrightness %s', err);
+                                            } else {
+                                                console.log('Brightness set to high ' + i2cAddress + " device " + i2cDevice);
+                                                //i2cdevice.setAddress(objOptions.I2CAddress);
+                                                port.writeBytes([0x00], [digits[0], 0x00, digits[0], 0x00, 0x00, 0x00, digits[0], 0x00, digits[0], 0x00], function (err) {
+                                                    if (err) {
+                                                        console.log('Error in write zeros ' + i2cAddress + " device " + i2cDevice, err);
+                                                    } else {
+                                                        console.log('wrote zeros ' + i2cAddress + " device " + i2cDevice);
+                                                    }
+                                                });
+                                                if (Callback) {
+                                                    Callback(err, port);
+                                                }
+                                            }
+                                        }); // setBrightness
+                                    }
+                                }); // setBlinkRate
+                            }
+                        }); //WriteData    // oscillator on
+
+                }
+            },
+            function (err, port) {
+                console.log('bonescript adafruitLedBackpack i2c.open');
+
+            }
+        ); // boneScript i2c Open
+    }
+
+
+
+    //Now Test multiple i2c devices same port  using 2 adafruit i2c LED 7 segment displays via the adafruit LEDBacpack HT16K33
+    //https://www.adafruit.com/products/879
+    //
+    var LedI2cDevicePath = '/dev/i2c-1';
+    var LedI2cAddress1 = '0x70';
+    var LedI2cAddress2 = '0x71';
+
+
+
+    // Open and write 1234 to LED Backpack 1
+    var LedI2cBackpack1;
+    testI2cOpen(LedI2cDevicePath, LedI2cAddress1, function (err, i2cPort) {
+        if (err) {
+            console.log(' LedI2cBackpack1 errored ' + err);
+        } else {
+            console.log(' LedI2cBackpack1 success ');
+            LedI2cBackpack1 = i2cPort;
+            LedI2cBackpack1.writeBytes([0x00], [digits[1], 0x00, digits[1], 0x00, 0x02, 0x00, digits[1], 0x00, digits[1], 0x00], function (err) {
+                if (err) {
+                    console.log('LedI2cBackpack1 Error in write 11:11', err);
+                } else {
+                    console.log('LedI2cBackpack1 wrote 11:11 ', LedI2cBackpack1);
+                }
+            });
+        }
+
+    });
+
+    // Open and write 1234 to LED Backpack 1
+    var LedI2cBackpack2;
+    testI2cOpen(LedI2cDevicePath, LedI2cAddress2, function (err, i2cPort) {
+        if (err) {
+            console.log(' LedI2cBackpack2 errored ' + err);
+        } else {
+            console.log(' LedI2cBackpack2 success ');
+            LedI2cBackpack2 = i2cPort;
+            LedI2cBackpack2.writeBytes([0x00], [digits[2], 0x00, digits[2], 0x00, 0x02, 0x00, digits[2], 0x00, digits[2], 0x00], function (err) {
+                if (err) {
+                    console.log('LedI2cBackpack2 Error in write 22:22', err);
+                } else {
+                    console.log('LedI2cBackpack2 wrote 22:22 ', LedI2cBackpack2);
+                }
+                // Another way to reuse the device but change address on the return but this will causes issues
+                // LedI2cBackpack2.address = LedI2cAddress1;
+                //LedI2cBackpack2.writeBytes([0x00], [digits[5], 0x00, digits[6], 0x00, 0x02, 0x00, digits[7], 0x00, digits[8], 0x00], function (err) {
+                //    if (err) {
+                //        console.log('LedI2cBackpack2 Error in write 12:34', err);
+                //    } else {
+                //        console.log('LedI2cBackpack2 wrote 12:34 ', LedI2cBackpack2);
+                //    }
+                //});
+            });
+
+        }
+
+    });
+
+
+} catch (e) {
+    console.log(e);
+}
+
+

--- a/index.js
+++ b/index.js
@@ -31,20 +31,12 @@ if (os.type() === 'Linux' && os.arch() === 'arm') {
 
     // AUTO_LOAD_CAPE can be used to turn off the autoloading of capes.
     if (typeof process.env.AUTO_LOAD_CAPE === 'undefined' || process.env.AUTO_LOAD_CAPE === '1') {
-
-        if (!bone.is_cape_universal()) {
-            debug('Loading Universal Cape interface...');
-            bone.load_dt_sync('cape-universaln');
-        }
-
-        // if (!bone.is_audio_enable()) {
-        //     debug('Loading AUDIO Cape...');
-        //     bone.load_dt_sync("cape-univ-audio");
-        // }
-
-        if (!bone.is_hdmi_enable()) {
-            debug('Loading HDMI Cape...');
-            bone.load_dt_sync('cape-univ-hdmi');
+        debug('Checking for Universal Cape interface... prevent with AUTO_LOAD_CAPE=0');
+        if (bone.is_cape_universal_loaded() == false) {
+            debug('No Universal Cape interface found will attempt to load...');
+            bone.load_universal_cape();
+        } else {
+            debug('Universal Cape interface already loaded ...');
         }
 
     }

--- a/lib/bone.js
+++ b/lib/bone.js
@@ -68,6 +68,90 @@ module.exports = {
         return (cape_universal);
     },
 
+    is_cape_universal_loaded: function () {
+
+        // the universal capes start with cape-univ and or univ- so we try to find them using those two names
+        var capemgr = module.exports.is_capemgr();
+        var slotsFile = capemgr + '/slots';
+        var slots = fs.readFileSync(slotsFile, 'ascii');
+        var slotRegex = new RegExp('\\d+(?=\\s*:.*,(cape-univ|univ-))', 'gm');
+        var foundUniv = slots.match(slotRegex);
+        debug('Slots returned ' + slots);
+        debug('found Universial at slot ' + foundUniv);
+        if (foundUniv) {
+            debug('Found Universial using ",cape-univ" or ",univ-" as filter');
+            return true;
+        } else {
+            debug('No Universial Cape Found');
+            return false;
+        }
+        
+        
+        
+    },
+    load_universal_cape: function (callback) {
+        // 06/02/2016 Andrew DeVries Logic based on dogtag BeagleBoard.org Debian Image 2016-05-13
+        // need to determine which universal cape to load based on board type ie BeagleBone Green has no HDMI etc.
+        //this logic was taken from https://github.com/RobertCNelson/boot-scripts/blob/master/boot/am335x_evm.sh#L321-L407
+        //the am335x_evm.sh script executes at boot and should autoload universal
+        // script is located at /opt/scripts/boot/am335x_evm.sh
+        //
+        // Note known issue on console image (lqxn image works correctly) BeagleBoard.org Debian Image 2016-05-13 where config-pin missing
+        // so universial is not loaded automaticaly at boot.
+        // Fix so script runs at boot is to add config-pin link
+        //
+        //  cd /opt/source/
+        //  sudo  git clone https://github.com/cdsteinkuehler/beaglebone-universal-io.git
+        //  sudo chmod a+ rwx / opt / source / beaglebone - universal - io / config - pin
+        //  cd / usr / local / bin /
+        //  sudo ln - s / opt / source / beaglebone - universal - io / config - pin config- pin
+
+        //
+        //overlays can be found here https://github.com/RobertCNelson/bb.org-overlays/tree/master/src/arm
+        // view loaded overlays 'cat /sys/devices/platform/bone_capemgr/slots'
+        // manual load of overlay 'sudo sh -c "echo 'univ-emmc' > /sys/devices/platform/bone_capemgr/slots"'
+        // manual unload of overlay 'sudo sh -c "echo '-4' > /sys/devices/platform/bone_capemgr/slots"'
+
+
+        // Check /proc/device-tree/model for the model
+        var overlay = 'cape-universaln'; 
+        try {
+            var machine = fs.readFileSync('/proc/device-tree/model', 'ascii');
+            if (machine) {
+                machine = machine.replace(/ /g, "_");
+            }
+            switch (machine) {
+                case 'TI_AM335x_BeagleBone':
+                    overlay = "univ-all";
+                    break;
+                case 'TI_AM335x_BeagleBone_Black_Wireless':
+                    overlay = "cape-universaln"
+                    break;
+                case 'TI_AM335x_BeagleBone_Black':
+                    overlay = "cape-universaln";
+                    break;
+                case 'TI_AM335x_BeagleBone_Green':
+                    overlay = "univ-emmc";
+                    break;
+                 case 'TI_AM335x_BeagleBone_Green_Wireless':
+                    overlay= "univ-bbgw";
+                    break;   
+            }
+            debug('Detected machine ' + machine + ' using Overlay ' + overlay );
+        } catch(err){
+            debug('Error detecting machine');
+        }
+        module.exports.load_dt_sync(overlay);
+        // if (!bone.is_audio_enable()) {
+        //     debug('Loading AUDIO Cape...');
+        //     bone.load_dt_sync("cape-univ-audio");
+        // }
+
+        //if (!bone.is_hdmi_enable()) {
+        //    debug('Loading HDMI Cape...');
+        //    bone.load_dt_sync('cape-univ-hdmi');
+        //}
+    },
     is_hdmi_enable: function() {
       var capemgr = module.exports.is_capemgr();
       var slotsFile = capemgr + '/slots';

--- a/lib/hw_universal.js
+++ b/lib/hw_universal.js
@@ -96,12 +96,14 @@ module.exports = {
             }
         });
         var x = eeproms['/sys/bus/i2c/drivers/at24/0-0050/eeprom'];
+        console.log('Andy Test x', x);
         if (x.boardName == 'A335BONE') platform.name = 'BeagleBone';
         if (x.boardName == 'A335BNLT') platform.name = 'BeagleBone Black';
         platform.version = x.version;
         if (!platform.version.match(/^[\040-\176]*$/)) delete platform.version;
         platform.serialNumber = x.serialNumber;
         if (!platform.serialNumber.match(/^[\040-\176]*$/)) delete platform.serialNumber;
+        if (platform.serialNumber && platform.serialNumber.substring(0,4) == 'BBG') platform.name = 'BeagleBone Green';
         try {
             platform.dogtag = fs.readFileSync('/etc/dogtag', 'ascii');
         } catch (ex) {}

--- a/lib/hw_universal.js
+++ b/lib/hw_universal.js
@@ -96,14 +96,12 @@ module.exports = {
             }
         });
         var x = eeproms['/sys/bus/i2c/drivers/at24/0-0050/eeprom'];
-        console.log('Andy Test x', x);
         if (x.boardName == 'A335BONE') platform.name = 'BeagleBone';
         if (x.boardName == 'A335BNLT') platform.name = 'BeagleBone Black';
         platform.version = x.version;
         if (!platform.version.match(/^[\040-\176]*$/)) delete platform.version;
         platform.serialNumber = x.serialNumber;
         if (!platform.serialNumber.match(/^[\040-\176]*$/)) delete platform.serialNumber;
-        if (platform.serialNumber && platform.serialNumber.substring(0,4) == 'BBG') platform.name = 'BeagleBone Green';
         try {
             platform.dogtag = fs.readFileSync('/etc/dogtag', 'ascii');
         } catch (ex) {}

--- a/lib/i2c.js
+++ b/lib/i2c.js
@@ -1,5 +1,6 @@
 // Copyright (C) 2013 - Texas Instruments, Jason Kridner
 // Modified by Aditya Patadia, Octal Consulting LLP
+// Modified by Andrew DeVries, Digital Example LLC move to path + address to allow multiple i2c slaves 
 var fs = require('fs');
 var verror = require("verror");
 var bone = require('./bone');
@@ -13,7 +14,7 @@ var i2c = {
 };
 
 module.exports = {
-	enable: function(path, callback) {
+    enable: function (path, callback) {
 		debug("i2c.enable(" + path + ")");
 		if (!i2c.ports[path]) {
 			throw new verror("Supplied path:" + path + " is not a vaild i2c port path.");
@@ -52,7 +53,6 @@ module.exports = {
 
 	open: function(path, address, handler, callback) {
 		debug("i2c.open(" + path + ", " + address + ")");
-
 		if (!i2c.ports[path]) {
 			throw new verror("Supplied path:" + path + " is not a vaild i2c port path.");
 		}
@@ -68,80 +68,80 @@ module.exports = {
 				throw new verror(err);
 			}
 
-			if (!i2c.openPorts[path]) {
+			if (!i2c.openPorts[path + ':' + address]) {
 				var port = new i2cPort(address, {
 					device: i2c.ports[path].path
 				});
-				debug('opened i2c port: ' + path);
+                debug('opened i2c port: ' + path + ':' + address);
 				port.on('data', handler);
-				i2c.openPorts[path] = port;
-				if (callback) callback(null, i2c.openPorts[path]);
+                i2c.openPorts[path + ':' + address] = port;
+                if (callback) callback(null, i2c.openPorts[path + ':' + address]);
 			} else {
-				if (callback) callback(null, i2c.openPorts[path]);
+                if (callback) callback(null, i2c.openPorts[path + ':' + address]);
 			}
 		}
 	},
 
-	writeByte: function(path, byte, callback) {
-		debug("i2c.writeByte(" + path + ", " + byte + ")");
-		if (!i2c.openPorts[path]) {
-			throw new verror("I2C port " + path + " is not open. Please call i2c.open function to open it.");
+	writeByte: function(path, address, byte, callback) {
+        debug("i2c.writeByte(" + path + ':' + address + ", " + byte + ")");
+        if (!i2c.openPorts[path + ':' + address]) {
+            throw new verror("I2C port " + path + ':' + address + " is not open. Please call i2c.open function to open it.");
 		}
-		var port = i2c.openPorts[path];
+        var port = i2c.openPorts[path + ':' + address];
 		port.writeByte(byte, callback);
 	},
 
-	writeBytes: function(path, command, byteArray, callback) {
+    writeBytes: function (path, address, command, byteArray, callback) {
 		debug("i2c.writeBytes(" + path + ", " + command + ", " + byteArray + ")");
-		if (!i2c.openPorts[path]) {
-			throw new verror("I2C port " + path + " is not open. Please call i2c.open function to open it.");
+        if (!i2c.openPorts[path + ':' + address]) {
+            throw new verror("I2C port " + path + ':' + address + " is not open. Please call i2c.open function to open it.");
 		}
-		var port = i2c.openPorts[path];
+        var port = i2c.openPorts[path + ':' + address];
 		port.writeBytes(command, byteArray, callback);
 	},
 
-	readByte: function(path, callback) {
-		debug("i2c.readByte(" + path + ")");
-		if (!i2c.openPorts[path]) {
-			throw new verror("I2C port " + path + " is not open. Please call i2c.open function to open it.");
+	readByte: function(path, address, callback) {
+        debug("i2c.readByte(" + path + ':' + address + ")");
+        if (!i2c.openPorts[path + ':' + address]) {
+            throw new verror("I2C port " + path + ':' + address + " is not open. Please call i2c.open function to open it.");
 		}
-		var port = i2c.openPorts[path];
+        var port = i2c.openPorts[path + ':' + address];
 		port.readByte(callback);
 	},
 
-	readBytes: function(path, command, length, callback) {
-		debug("i2c.readBytes(" + path + ", " + command + ", " + length + ")");
-		if (!i2c.openPorts[path]) {
-			throw new verror("I2C port " + path + " is not open. Please call i2c.open function to open it.");
+	readBytes: function(path, address, command, length, callback) {
+        debug("i2c.readBytes(" + path + ':' + address + ", " + command + ", " + length + ")");
+        if (!i2c.openPorts[path + ':' + address]) {
+            throw new verror("I2C port " + path + ':' + address + " is not open. Please call i2c.open function to open it.");
 		}
-		var port = i2c.openPorts[path];
+        var port = i2c.openPorts[path + ':' + address];
 		port.readBytes(command, length, callback);
 	},
 
-	stream: function(path, command, length, delay) {
-		debug("i2c.readBytes(" + path + ", " + command + ", " + length + ", " + delay + ")");
-		if (!i2c.openPorts[path]) {
-			throw new verror("I2C port " + path + " is not open. Please call i2c.open function to open it.");
+	stream: function(path, address, command, length, delay) {
+        debug("i2c.readBytes(" + path + ':' + address + ", " + command + ", " + length + ", " + delay + ")");
+        if (!i2c.openPorts[path + ':' + address]) {
+            throw new verror("I2C port " + path + ':' + address + " is not open. Please call i2c.open function to open it.");
 		}
-		var port = i2c.openPorts[path];
+        var port = i2c.openPorts[path + ':' + address];
 		port.stream(command, length, delay);
 	},
 
-	write: function(path, byteArray, callback) {
-		debug("i2c.readBytes(" + path + ", " + byteArray + ")");
+    write: function (path, address, byteArray, callback) {
+        debug("i2c.readBytes(" + path + ':' + address + ", " + byteArray + ")");
 		if (!i2c.openPorts[path]) {
-			throw new verror("I2C port " + path + " is not open. Please call i2c.open function to open it.");
+            throw new verror("I2C port " + path + ':' + address + " is not open. Please call i2c.open function to open it.");
 		}
-		var port = i2c.openPorts[path];
+        var port = i2c.openPorts[path + ':' + address];
 		port.write(byteArray, callback);
 	},
 
 	read: function(path, length, callback) {
-		debug("i2c.readBytes(" + path + ", " + length + ")");
-		if (!i2c.openPorts[path]) {
-			throw new verror("I2C port " + path + " is not open. Please call i2c.open function to open it.");
+        debug("i2c.readBytes(" + path + ':' + address + ", " + length + ")");
+        if (!i2c.openPorts[path + ':' + address]) {
+            throw new verror("I2C port " + path + ':' + address + " is not open. Please call i2c.open function to open it.");
 		}
-		var port = i2c.openPorts[path];
+        var port = i2c.openPorts[path + ':' + address];
 		port.read(length, callback);
 	},
 


### PR DESCRIPTION
Fixes for path + address return different I2c device references as
typical to have multiple address on same path.

Test Case added to examples/i2c_multiple_adafruitled7Segs.js  

Test cases uses 2 adafruit LED 7 Segment backbacks but any two i2c devices can be used on same i2c path with different addresses.