### PR TITLE
Overlays: detect when u-boot setup overlays/cape-universal

### DIFF
--- a/lib/bone.js
+++ b/lib/bone.js
@@ -78,13 +78,23 @@ module.exports = {
         var foundUniv = slots.match(slotRegex);
         debug('Slots returned ' + slots);
         debug('found Universial at slot ' + foundUniv);
-        if (foundUniv) {
-            debug('Found Universial using ",cape-univ" or ",univ-" as filter');
-            return true;
-        } else {
-            debug('No Universial Cape Found');
-            return false;
-        }
+        // U-Boot overlays will pass bone_capemgr.uboot_capemgr_enabled=1 thru /proc/cmdline
+        const exec = require('child_process').exec;
+        exec('grep -c bone_capemgr.uboot_capemgr_enabled=1 /proc/cmdline', (error, stdout, stderr)=> {
+            if (error) {
+                // Classic load path (uboot not loading cape universal)
+                if (foundUniv) {
+                    debug('Found Universial using ",cape-univ" or ",univ-" as filter');
+                    return true;
+                } else {
+                    debug('No Universial Cape Found');
+                    return false;
+                }
+            } else {
+                debug('U-Boot Overlays providing cape Universal');
+                return true;
+            }
+        });
         
         
         


### PR DESCRIPTION
Since about July 1st, we've migrated to U-Boot overlays by default:

http://elinux.org/Beagleboard:BeagleBoneBlack_Debian#U-Boot_Overlays

Just too many race conditions to deal with, when doing kernel overlays.  So U-Boot takes care of applying all the overlays, and it pass a cmdline option:

bone_capemgr.uboot_capemgr_enabled=1 

to hint to us to NOT try to load anymore overlays in kernel land.

The exec call is a little hackish, (javascript newbie) we get an "error" when grep doesn't find the cmdline option, thus it'll drop into the old function.

Signed-off-by: Robert Nelson <robertcnelson@gmail.com>